### PR TITLE
Use the user defined to map the device

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -807,7 +807,7 @@ func (d *cephRBDVolumeDriver) unlockImage(pool, imagename, locker string) error 
 
 // mapImage will map the RBD Image to a kernel device
 func (d *cephRBDVolumeDriver) mapImage(pool, imagename string) (string, error) {
-	return sh("rbd", "map", "--pool", pool, imagename)
+	return sh("rbd", "map", "--id", d.user, "--pool", pool, imagename)
 }
 
 // unmapImageDevice will release the mapped kernel device


### PR DESCRIPTION
We need to honour the user specified to map the rbd image.

Signed-off-by: Sébastien Han seb@redhat.com
