### PR TITLE
Add missing API calls for Docker 1.9+

### DIFF
--- a/contrib/el7/Makefile
+++ b/contrib/el7/Makefile
@@ -9,8 +9,8 @@ env:
 	rpmdev-setuptree
 	cp -Rvf S* ~/rpmbuild
 	wget -O ~/rpmbuild/SOURCES/0.1.9.tar.gz https://github.com/yp-engineering/rbd-docker-plugin/archive/0.1.9.tar.gz
-	wget -O ~/rpmbuild/SOURCES/rbd-docker-plugin_logrotate https://raw.githubusercontent.com/sheepkiller/rbd-docker-plugin/master/logrotate.d/rbd-docker-plugin_logrotate
+	wget -O ~/rpmbuild/SOURCES/rbd-docker-plugin_logrotate https://raw.githubusercontent.com/sheepkiller/rbd-docker-plugin-rpm/master/logrotate.d/rbd-docker-plugin_logrotate
 
 depends:
-	yum install -y http://ceph.com/rpm-hammer/el7/noarch/ceph-release-1-1.el7.noarch.rpm epel-release
+	yum install -y http://ceph.com/rpm-infernalis/el7/noarch/ceph-release-1-1.el7.noarch.rpm epel-release
 	yum install -y librados2-devel librbd1-devel golang git epel-release rpmdevtools make wget

--- a/contrib/el7/SPECS/rbd-docker-plugin.spec
+++ b/contrib/el7/SPECS/rbd-docker-plugin.spec
@@ -14,6 +14,7 @@ Source0: https://github.com/yp-engineering/rbd-docker-plugin/archive/%{version}.
 Source1: rbd-docker-plugin.service
 Source2: rbd-docker-plugin.conf
 Source3: rbd-docker-plugin-wrapper
+Source4: rbd-docker-plugin_logrotate
 ExclusiveArch:  x86_64
 BuildRoot: %{_tmppath}/%{name}-%{version}
 BuildRequires: golang >= 1.4.2
@@ -28,7 +29,6 @@ Requires(postun): systemd
 Requires: ceph >= 0.94.0
 Requires: librados2 >= 0.94.0
 Requires: librbd1 >= 0.94.0
-
 Requires: docker-engine >= 1.8.0
 
 %description
@@ -52,18 +52,22 @@ install -d %{buildroot}%{_unitdir}
 install -d %{buildroot}%{_sysconfdir}/docker/
 install -p -m 755 dist/%{name} %{buildroot}%{_libexecdir}/%{name}
 install -p -m 644 %{S:1}  %{buildroot}%{_unitdir}/
-
 sed -e "s,%%LIBEXEC%%,%{_libexecdir}," %{S:3} >  %{buildroot}%{_bindir}/rbd-docker-plugin-wrapper
 chmod 755 %{buildroot}%{_bindir}/rbd-docker-plugin-wrapper
 sed -e "s,%%LIBEXEC%%,%{_libexecdir}," %{S:2} > %{buildroot}%{_sysconfdir}/docker/rbd-docker-plugin.conf
 chmod 644 %{buildroot}%{_sysconfdir}/docker/rbd-docker-plugin.conf
+
+mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d
+install -m 644 %{S:4} $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/rbd-docker-plugin
 
 %files
 %defattr(-,root,root)
 %{_unitdir}/rbd-docker-plugin.service
 %{_libexecdir}/%{name}
 %{_bindir}/rbd-docker-plugin-wrapper
+%{_sysconfdir}/logrotate.d/rbd-docker-plugin
 %config(noreplace) %{_sysconfdir}/docker/%{name}.conf
+
 %post
 %systemd_post rbd-docker-plugin.service
 
@@ -79,6 +83,9 @@ fi
 /usr/bin/systemctl daemon-reload >/dev/null 2>&1 || true
 
 %changelog
+* Thu Sep 10 2015 sheepkiller
+- add logrotate
+- fix runtime deps
 * Wed Sep 09 2015 sheepkiller
 - move plugin to /usr/libexec
 - add wrapper + config

--- a/driver.go
+++ b/driver.go
@@ -361,16 +361,19 @@ func (d cephRBDVolumeDriver) Mount(r dkvolume.Request) dkvolume.Response {
 //
 // Request:
 //    {}
-//    Docker needs reminding of the path to the volume on the host.
+//    List the volumes mapped by this plugin.
 //
 // Response:
 //    { "Volumes": [ { "Name": "volume_name", "Mountpoint": "/path/to/directory/on/host" } ], "Err": null }
-//    Respond with the path on the host filesystem where the volume has been
-//    made available, and/or a string error if an error occurred.
+//    Respond with an array containing pairs of known volume names and their
+//    respective paths on the host filesystem (where the volumes have been
+//    made available).
 //
 func (d cephRBDVolumeDriver) List(r dkvolume.Request) dkvolume.Response {
 	vols := make([]*dkvolume.Volume, 0, len(d.volumes))
+	// for each registered mountpoint
 	for k, v := range d.volumes {
+		// append it and its name to the result
 		vols = append(vols, &dkvolume.Volume{
 			Name: v.name,
 			Mountpoint: k,
@@ -391,8 +394,9 @@ func (d cephRBDVolumeDriver) List(r dkvolume.Request) dkvolume.Response {
 //
 // Response:
 //    { "Volume": { "Name": "volume_name", "Mountpoint": "/path/to/directory/on/host" }, "Err": null }
-//    Respond with the path on the host filesystem where the volume has been
-//    made available, and/or a string error if an error occurred.
+//    Respond with a tuple containing the name of the queried volume and the
+//    path on the host filesystem where the volume has been made available,
+//    and/or a string error if an error occurred.
 //
 func (d cephRBDVolumeDriver) Get(r dkvolume.Request) dkvolume.Response {
 	// parse full image name for optional/default pieces


### PR DESCRIPTION
Hello,

This is my quick attempt at fixing #21 #23. I've done some quick tests on CentOS 7.2 with docker 1.10.2 and ceph 9.2.0 and it seems to work for me.

The Get call is just a copy-paste of Path, with a slightly different output format, as per docs, while the List call is a simple implementation, with no error checking, as apparently make and append can't fail? (I'm a Go noob, this is actually my first time using it.)

I've also included some misc changes that seemed small/harmless enough to not warrant a different PR:
- updated contrib/el7/Makefile to the current Ceph release and proper location for the logrotate config (I guess the project was renamed?)
- updated the SPEC file from rbd-docker-plugin-rpm as well, to include the default logrotate.d configuration file
