### PR TITLE
Remove size definition in image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
   * plugin can only be configured for a single Ceph User (currently no 
     good way to pass things from docker -> plugin, get only volume name)
   * run multiple plugin instances for varying configs (ceph user, default pool, default size)
-  * can pass extra config via volume name to override default pool and creation size:
-    * docker run --volume-driver rbd -v poolname/imagename@size:/mnt/disk1 ...
+  * can pass extra config via volume name to override default pool:
+    * docker run --volume-driver rbd -v poolname/imagename:/mnt/disk1 ...
 
 * plugin supports all Docker VolumeDriver Plugin API commands:
   * Create - can provision Ceph RBD Image in a pool of a certain size
@@ -158,9 +158,8 @@ This plugin can create RBD images with XFS filesystem.
   * Volume will be locked, mapped and mounted to Host and bind-mounted to container at `/mnt/foo`
   * When container exits, the volume will be unmounted, unmapped and unlocked
   * You can control the RBD Pool and initial Size using this syntax:
-    * foo@1024 => pool=rbd (default), image=foo, size 1GB
+    * foo => pool=rbd (default), image=foo and default `--size` (20GB)
     * deep/foo =>  pool=deep, image=foo and default `--size` (20GB)
-    * deep/foo@1024 => pool=deep, image=foo, size 1GB
     - pool must already exist
 
 ### Misc

--- a/driver.go
+++ b/driver.go
@@ -41,7 +41,7 @@ import (
 )
 
 var (
-	imageNameRegexp = regexp.MustCompile(`^(([-_.[:alnum:]]+)/)?([-_.[:alnum:]]+)(@([0-9]+))?$`) // optional pool or size in image name
+	imageNameRegexp = regexp.MustCompile(`^(([-_.[:alnum:]]+)/)?([-_.[:alnum:]]+)$`)
 )
 
 // Volume is the Docker concept which we map onto a Ceph RBD Image
@@ -146,7 +146,7 @@ func (d cephRBDVolumeDriver) createImage(r dkvolume.Request) dkvolume.Response {
 	fstype := *defaultImageFSType
 
 	// parse image name optional/default pieces
-	pool, name, size, err := d.parseImagePoolNameSize(r.Name)
+	pool, name, err := d.parseImagePoolName(r.Name)
 	if err != nil {
 		log.Printf("ERROR: parsing volume: %s", err)
 		return dkvolume.Response{Err: err.Error()}
@@ -156,11 +156,11 @@ func (d cephRBDVolumeDriver) createImage(r dkvolume.Request) dkvolume.Response {
 	if r.Options["pool"] != "" {
 		pool = r.Options["pool"]
 	}
+	size := *defaultImageSizeMB
 	if r.Options["size"] != "" {
 		size, err = strconv.Atoi(r.Options["size"])
 		if err != nil {
 			log.Printf("WARN: using default size. unable to parse int from %s: %s", r.Options["size"], err)
-			size = *defaultImageSizeMB
 		}
 	}
 	if r.Options["fstype"] != "" {
@@ -220,7 +220,7 @@ func (d cephRBDVolumeDriver) Remove(r dkvolume.Request) dkvolume.Response {
 	defer d.m.Unlock()
 
 	// parse full image name for optional/default pieces
-	pool, name, _, err := d.parseImagePoolNameSize(r.Name)
+	pool, name, err := d.parseImagePoolName(r.Name)
 	if err != nil {
 		log.Printf("ERROR: parsing volume: %s", err)
 		return dkvolume.Response{Err: err.Error()}
@@ -298,7 +298,7 @@ func (d cephRBDVolumeDriver) Mount(r dkvolume.Request) dkvolume.Response {
 	defer d.m.Unlock()
 
 	// parse full image name for optional/default pieces
-	pool, name, _, err := d.parseImagePoolNameSize(r.Name)
+	pool, name, err := d.parseImagePoolName(r.Name)
 	if err != nil {
 		log.Printf("ERROR: parsing volume: %s", err)
 		return dkvolume.Response{Err: err.Error()}
@@ -427,7 +427,7 @@ func (d cephRBDVolumeDriver) List(r dkvolume.Request) dkvolume.Response {
 //
 func (d cephRBDVolumeDriver) Get(r dkvolume.Request) dkvolume.Response {
 	// parse full image name for optional/default pieces
-	pool, name, _, err := d.parseImagePoolNameSize(r.Name)
+	pool, name, err := d.parseImagePoolName(r.Name)
 	if err != nil {
 		log.Printf("ERROR: parsing volume: %s", err)
 		return dkvolume.Response{Err: err.Error()}
@@ -455,7 +455,7 @@ func (d cephRBDVolumeDriver) Get(r dkvolume.Request) dkvolume.Response {
 //
 func (d cephRBDVolumeDriver) Path(r dkvolume.Request) dkvolume.Response {
 	// parse full image name for optional/default pieces
-	pool, name, _, err := d.parseImagePoolNameSize(r.Name)
+	pool, name, err := d.parseImagePoolName(r.Name)
 	if err != nil {
 		log.Printf("ERROR: parsing volume: %s", err)
 		return dkvolume.Response{Err: err.Error()}
@@ -490,7 +490,7 @@ func (d cephRBDVolumeDriver) Unmount(r dkvolume.Request) dkvolume.Response {
 	var err_msgs = []string{}
 
 	// parse full image name for optional/default pieces
-	pool, name, _, err := d.parseImagePoolNameSize(r.Name)
+	pool, name, err := d.parseImagePoolName(r.Name)
 	if err != nil {
 		log.Printf("ERROR: parsing volume: %s", err)
 		return dkvolume.Response{Err: err.Error()}
@@ -651,33 +651,29 @@ func (d *cephRBDVolumeDriver) mountpoint(pool, name string) string {
 	return filepath.Join(d.root, pool, name)
 }
 
-// parseImagePoolNameSize parses out any optional parameters from Image Name
+// parseImagePoolName parses out any optional parameters from Image Name
 // passed from docker run. Fills in unspecified options with default pool or
 // size.
 //
 // Returns: pool, image-name, size, error
 //
-func (d *cephRBDVolumeDriver) parseImagePoolNameSize(fullname string) (string, string, int, error) {
+func (d *cephRBDVolumeDriver) parseImagePoolName(fullname string) (string, string, error) {
 	// Examples of regexp matches:
-	//   foo: ["foo" "" "" "foo" "" ""]
-	//   foo@1024: ["foo@1024" "" "" "foo" "@1024" "1024"]
-	//   pool/foo: ["pool/foo" "pool/" "pool" "foo" "" ""]
-	//   pool/foo@1024: ["pool/foo@1024" "pool/" "pool" "foo" "@1024" "1024"]
+	//   foo: ["foo" "" "" "foo"]
+	//   pool/foo: ["pool/foo" "pool/" "pool" "foo"]
 	//
 	// Match indices:
 	//   0: matched string
 	//   1: pool with slash
 	//   2: pool no slash
 	//   3: image name
-	//   4: size with @
-	//   5: size only
 	//
 	matches := imageNameRegexp.FindStringSubmatch(fullname)
 	if isDebugEnabled() {
-		log.Printf("DEBUG: parseImagePoolNameSize: \"%s\": %q", fullname, matches)
+		log.Printf("DEBUG: parseImagePoolName: \"%s\": %q", fullname, matches)
 	}
-	if len(matches) != 6 {
-		return "", "", 0, errors.New("Unable to parse image name: " + fullname)
+	if len(matches) != 4 {
+		return "", "", errors.New("Unable to parse image name: " + fullname)
 	}
 
 	// 2: pool
@@ -689,18 +685,7 @@ func (d *cephRBDVolumeDriver) parseImagePoolNameSize(fullname string) (string, s
 	// 3: image
 	imagename := matches[3]
 
-	// 5: size
-	size := *defaultImageSizeMB
-	if matches[5] != "" {
-		var err error
-		size, err = strconv.Atoi(matches[5])
-		if err != nil {
-			log.Printf("WARN: using default. unable to parse int from %s: %s", matches[5], err)
-			size = *defaultImageSizeMB
-		}
-	}
-
-	return pool, imagename, size, nil
+	return pool, imagename, nil
 }
 
 // rbdImageExists will check for an existing Ceph RBD Image

--- a/driver.go
+++ b/driver.go
@@ -706,25 +706,27 @@ func (d *cephRBDVolumeDriver) parseImagePoolNameSize(fullname string) (string, s
 // rbdImageExists will check for an existing Ceph RBD Image
 func (d *cephRBDVolumeDriver) rbdImageExists(pool, findName string) (bool, error) {
 	log.Printf("INFO: rbdImageExists(%s/%s)", pool, findName)
-	if findName != "" {
-		ctx, err := d.openContext(pool)
-		if err != nil {
-			return false, err
-		}
-		defer d.shutdownContext(ctx)
-
-		rbdImageNames, err := rbd.GetImageNames(ctx)
-		if err != nil {
-			log.Printf("ERROR: Unable to get Ceph RBD Image list: %s", err)
-			return false, err
-		}
-		for _, imageName := range rbdImageNames {
-			if imageName == findName {
-				return true, nil
-			}
-		}
+	if findName == "" {
+		return false, fmt.Errorf("Empty Ceph RBD Image name")
 	}
-	return false, nil
+
+	ctx, err := d.openContext(pool)
+	if err != nil {
+		return false, err
+	}
+	defer d.shutdownContext(ctx)
+
+	img := rbd.GetImage(ctx, findName)
+	err = img.Open(true)
+	defer img.Close()
+	if err != nil {
+		if err == rbd.RbdErrorNotFound {
+			log.Printf("INFO: Ceph RBD Image ('%s') not found: %s", findName, err)
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 // createRBDImage will create a new Ceph block device and make a filesystem on it


### PR DESCRIPTION
> There is one related PR #37 , please review that first.

If we put `@<size>` at the end of the image name, Docker won't recognize
it, and Docker will save `<image-name>@<size>` as the volume name.
However, this image is actually the same one as `<image-name>`, without
suffix. We should make Docker treating them as the same image, instead
of two different ones. This is important because Docker caches the
volume info, the volume has been referenced by which container, by
image name.

> see the code of `setNamed(v volume.Volume, ref string)` in
> [github.com/docker/docker/volume/store/store.go](https://github.com/docker/docker/blob/v1.11.2/volume/store/store.go#L84-L91)

After this change, when creating images at `docker run`, plugin will statically
use the default value. When creating images by `docker volume create`,
user can pass size in opts to declare a customized value.
