### PR TITLE
Unmount rbd when remove containers

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -219,32 +219,32 @@ func (d cephRBDVolumeDriver) Remove(r dkvolume.Request) dkvolume.Response {
 	}
 
 	// attempt to gain lock before remove - lock disappears after rm or rename
-	locker, err := d.lockImage(pool, name)
-	if err != nil {
-		errString := fmt.Sprintf("Unable to lock image for remove: %s", name)
-		log.Println("ERROR: " + errString)
-		return dkvolume.Response{Err: errString}
-	}
+	// locker, err := d.lockImage(pool, name)
+	// if err != nil {
+	// 	errString := fmt.Sprintf("Unable to lock image for remove: %s", name)
+	// 	log.Println("ERROR: " + errString)
+	// 	return dkvolume.Response{Err: errString}
+	// }
 
-	if *canRemoveVolumes {
-		// remove it (for real - destroy it ... )
-		err = d.removeRBDImage(pool, name)
-		if err != nil {
-			errString := fmt.Sprintf("Unable to remove Ceph RBD Image(%s): %s", name, err)
-			log.Println("ERROR: " + errString)
-			defer d.unlockImage(pool, name, locker)
-			return dkvolume.Response{Err: errString}
-		}
-	} else {
-		// just rename it (in case needed later, or can be culled via script)
-		err = d.renameRBDImage(pool, name, "zz_"+name)
-		if err != nil {
-			errString := fmt.Sprintf("Unable to rename with zz_ prefix: RBD Image(%s): %s", name, err)
-			log.Println("ERROR: " + errString)
-			defer d.unlockImage(pool, name, locker)
-			return dkvolume.Response{Err: errString}
-		}
-	}
+	// if *canRemoveVolumes {
+	// 	// remove it (for real - destroy it ... )
+	// 	err = d.removeRBDImage(pool, name)
+	// 	if err != nil {
+	// 		errString := fmt.Sprintf("Unable to remove Ceph RBD Image(%s): %s", name, err)
+	// 		log.Println("ERROR: " + errString)
+	// 		defer d.unlockImage(pool, name, locker)
+	// 		return dkvolume.Response{Err: errString}
+	// 	}
+	// } else {
+	// 	// just rename it (in case needed later, or can be culled via script)
+	// 	err = d.renameRBDImage(pool, name, "zz_"+name)
+	// 	if err != nil {
+	// 		errString := fmt.Sprintf("Unable to rename with zz_ prefix: RBD Image(%s): %s", name, err)
+	// 		log.Println("ERROR: " + errString)
+	// 		defer d.unlockImage(pool, name, locker)
+	// 		return dkvolume.Response{Err: errString}
+	// 	}
+	// }
 
 	delete(d.volumes, mount)
 	return dkvolume.Response{}

--- a/driver.go
+++ b/driver.go
@@ -520,7 +520,7 @@ func (d cephRBDVolumeDriver) Unmount(r dkvolume.Request) dkvolume.Response {
 	return dkvolume.Response{}
 }
 
-func (d cephRBDVolumeDriver) InnerUnMount(imageName string) err {
+func (d cephRBDVolumeDriver) InnerUnMount(imageName string) {
 	d.m.Lock()
 	defer d.m.Unlock()
 
@@ -530,7 +530,7 @@ func (d cephRBDVolumeDriver) InnerUnMount(imageName string) err {
 	pool, name, _, err := d.parseImagePoolNameSize(imageName)
 	if err != nil {
 		log.Printf("ERROR: parsing volume: %s", err)
-		return dkvolume.Response{Err: err.Error()}
+		return
 	}
 
 	mount := d.mountpoint(pool, name)
@@ -578,10 +578,10 @@ func (d cephRBDVolumeDriver) InnerUnMount(imageName string) err {
 
 	// check for piled up errors
 	if len(err_msgs) > 0 {
-		return errors.New(strings.Join(err_msgs, ", "))
+		return
 	}
 
-	return nil
+	return
 }
 
 // END Docker VolumeDriver Plugin API methods
@@ -599,7 +599,7 @@ func (d *cephRBDVolumeDriver) shutdown() {
 	defer d.m.Unlock()
 
 	// for each registered mountpoint
-	for k, v := range d.volumes {
+	for _, v := range d.volumes {
 		d.InnerUnMount(v.name)
 	}
 


### PR DESCRIPTION
`rbd-docker-plugin` is necessary when using distributed docker cluster. It is not acceptable to remove the data volume during container rescheduled from one machine to another. 

And the comment near `Remove` function is talking about the behavior in `mesos/marathon` env. I think that unmount the rbd is the best way to handle this right now. But I still comment (not remove) the original code right now.
