### PR TITLE
	check in by feijian

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -292,7 +292,7 @@ func (d cephRBDVolumeDriver) Remove(r dkvolume.Request) dkvolume.Response {
 //    Respond with the path on the host filesystem where the volume has been
 //    made available, and/or a string error if an error occurred.
 //
-func (d cephRBDVolumeDriver) Mount(r dkvolume.Request) dkvolume.Response {
+func (d cephRBDVolumeDriver) Mount(r dkvolume.MountRequest) dkvolume.Response {
 	log.Printf("INFO: Mount(%s)", r.Name)
 	d.m.Lock()
 	defer d.m.Unlock()
@@ -483,7 +483,7 @@ func (d cephRBDVolumeDriver) Path(r dkvolume.Request) dkvolume.Response {
 //    { "Err": null }
 //    Respond with a string error if an error occurred.
 //
-func (d cephRBDVolumeDriver) Unmount(r dkvolume.Request) dkvolume.Response {
+func (d cephRBDVolumeDriver) Unmount(r dkvolume.UnmountRequest) dkvolume.Response {
 	log.Printf("INFO: Unmount(%s)", r.Name)
 	d.m.Lock()
 	defer d.m.Unlock()
@@ -546,6 +546,12 @@ func (d cephRBDVolumeDriver) Unmount(r dkvolume.Request) dkvolume.Response {
 	}
 
 	return dkvolume.Response{}
+}
+
+func (d cephRBDVolumeDriver) Capabilities(r dkvolume.Request) dkvolume.Response {
+    var res dkvolume.Response
+    res.Capabilities = dkvolume.Capability{Scope: "local"}
+    return res
 }
 
 // END Docker VolumeDriver Plugin API methods


### PR DESCRIPTION
```
bug: missing Capabilities Volume API method for CephRBDVolumeDriver
    and  Mount API Unmount API parameter dkvolume.MountRequest
    dkvolume.UnmountRequest  in driver.go
```
